### PR TITLE
Pass correct asset to `GetAssetSpotPrice`

### DIFF
--- a/include/qfm/market_data_provider.hpp
+++ b/include/qfm/market_data_provider.hpp
@@ -12,8 +12,8 @@ namespace qfm {
 
 class MarketDataProvider {
  public:
-  double GetAssetSpotPrice(std::shared_ptr<asset::Asset> asset) const noexcept;
-  double GetAssetVolatility(std::shared_ptr<asset::Asset> asset) const noexcept;
+  double GetAssetSpotPrice(const std::string& asset) const noexcept;
+  double GetAssetVolatility(const std::string& asset) const noexcept;
   double GetInterestRate() const noexcept;
 };
 }  // namespace qfm

--- a/src/qfm/market_data_provider.cpp
+++ b/src/qfm/market_data_provider.cpp
@@ -2,21 +2,20 @@
 // Created by Durante, Matteo on 19/8/23.
 //
 
-#include "qfm/market_data_provider.hpp"
-
 #include <memory>
 
 #include "qfm/asset/asset.hpp"
+#include "qfm/market_data_provider.hpp"
 
 namespace qfm {
 
 double MarketDataProvider::GetAssetSpotPrice(
-    std::shared_ptr<asset::Asset> asset) const noexcept {
+    const std::string& asset) const noexcept {
   return 1.0;
 }
 
 double MarketDataProvider::GetAssetVolatility(
-    std::shared_ptr<asset::Asset> asset) const noexcept {
+    const std::string& asset) const noexcept {
   return 1.0;
 }
 


### PR DESCRIPTION
We are addressing this issue https://github.com/Waifod/quant_finance_models/issues/19

We were passing the option itself instead of the underlying.

To fix this, we modify the `MarketDataProvider` methods to accept a `std::string` instead of an asset and correct the Black-Scholes implementation by passing the ticker of the underlying to the relevant methods.

The formatting was broken once more. I will create a new issue to add autoformatting to the GitHub workflow.