### PR TITLE
Use `enum class` instead of plain `enum`

### DIFF
--- a/include/qfm/asset/asset_type.hpp
+++ b/include/qfm/asset/asset_type.hpp
@@ -5,7 +5,7 @@
 namespace qfm {
 namespace asset {
 
-enum AssetType { CURRENCY, BOND, STOCK, CALL_OPTION, PUT_OPTION, FUTURE };
+enum class AssetType { CURRENCY, BOND, STOCK, CALL_OPTION, PUT_OPTION, FUTURE };
 
 std::string ToString(const AssetType& type);
 

--- a/src/qfm/asset/asset_type.cpp
+++ b/src/qfm/asset/asset_type.cpp
@@ -14,17 +14,17 @@ const std::string kFuture = "future";
 
 std::string ToString(const AssetType& type) {
   switch (type) {
-    case CURRENCY:
+    case AssetType::CURRENCY:
       return kCurrency;
-    case BOND:
+    case AssetType::BOND:
       return kBond;
-    case STOCK:
+    case AssetType::STOCK:
       return kStock;
-    case CALL_OPTION:
+    case AssetType::CALL_OPTION:
       return kCallOption;
-    case PUT_OPTION:
+    case AssetType::PUT_OPTION:
       return kPutOption;
-    case FUTURE:
+    case AssetType::FUTURE:
       return kFuture;
   }
 }


### PR DESCRIPTION
Addresses minor comment on  [#47]

> Best practice states that this should be `enum class` instead.
> See [Enum.3: Prefer class enums over “plain” enums] from C++ Core Guidelines.

[#47]: https://github.com/Waifod/quant_finance_models/pull/47
[Enum.3: Prefer class enums over “plain” enums]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#enum3-prefer-class-enums-over-plain-enums