### PR TITLE
Pass `double` variable by value to class methods

### DIFF
--- a/include/qfm/asset/asset_strike_price.hpp
+++ b/include/qfm/asset/asset_strike_price.hpp
@@ -7,21 +7,21 @@ namespace asset {
 
 class AssetStrikePrice {
  public:
-  explicit AssetStrikePrice(const double& strike_price) noexcept;
+  explicit AssetStrikePrice(double strike_price) noexcept;
   ~AssetStrikePrice() = default;
 
-  bool operator==(const double& price) const;
-  bool operator!=(const double& price) const;
-  bool operator<=(const double& price) const;
-  bool operator>=(const double& price) const;
-  bool operator<(const double& price) const;
-  bool operator>(const double& price) const;
+  bool operator==(double price) const;
+  bool operator!=( double price) const;
+  bool operator<=( double price) const;
+  bool operator>=( double price) const;
+  bool operator<( double price) const;
+  bool operator>( double price) const;
 
   operator double() const;
   operator std::string() const;
 
  private:
-  double strike_price_;
+  const double strike_price_;
 };
 
 }  // namespace asset

--- a/include/qfm/asset/asset_type.hpp
+++ b/include/qfm/asset/asset_type.hpp
@@ -5,7 +5,7 @@
 namespace qfm {
 namespace asset {
 
-enum AssetType { CURRENCY, BOND, STOCK, CALL_OPTION, PUT_OPTION, FUTURE };
+enum class AssetType { CURRENCY, BOND, STOCK, CALL_OPTION, PUT_OPTION, FUTURE };
 
 std::string ToString(const AssetType& type);
 

--- a/include/qfm/asset/trait/strike_price_trait.hpp
+++ b/include/qfm/asset/trait/strike_price_trait.hpp
@@ -10,7 +10,7 @@ namespace trait {
 class StrikePriceTrait : public AssetTrait {
  public:
   explicit StrikePriceTrait(const AssetStrikePrice& strike_price) noexcept;
-  explicit StrikePriceTrait(const double& strike_price) noexcept;
+  explicit StrikePriceTrait(double strike_price) noexcept;
   ~StrikePriceTrait() = default;
   static const std::string Key;
 };

--- a/src/qfm/asset/asset_strike_price.cpp
+++ b/src/qfm/asset/asset_strike_price.cpp
@@ -5,25 +5,25 @@
 namespace qfm {
 namespace asset {
 
-AssetStrikePrice::AssetStrikePrice(const double& strike_price) noexcept
+AssetStrikePrice::AssetStrikePrice(double strike_price) noexcept
     : strike_price_{strike_price} {}
 
-bool AssetStrikePrice::operator==(const double& price) const {
+bool AssetStrikePrice::operator==(double price) const {
   return strike_price_ == price;
 }
-bool AssetStrikePrice::operator!=(const double& price) const {
+bool AssetStrikePrice::operator!=(double price) const {
   return strike_price_ != price;
 }
-bool AssetStrikePrice::operator<=(const double& price) const {
+bool AssetStrikePrice::operator<=(double price) const {
   return strike_price_ <= price;
 }
-bool AssetStrikePrice::operator>=(const double& price) const {
+bool AssetStrikePrice::operator>=(double price) const {
   return strike_price_ >= price;
 }
-bool AssetStrikePrice::operator<(const double& price) const {
+bool AssetStrikePrice::operator<(double price) const {
   return strike_price_ < price;
 }
-bool AssetStrikePrice::operator>(const double& price) const {
+bool AssetStrikePrice::operator>(double price) const {
   return strike_price_ > price;
 }
 

--- a/src/qfm/asset/asset_type.cpp
+++ b/src/qfm/asset/asset_type.cpp
@@ -14,17 +14,17 @@ const std::string kFuture = "future";
 
 std::string ToString(const AssetType& type) {
   switch (type) {
-    case CURRENCY:
+    case AssetType::CURRENCY:
       return kCurrency;
-    case BOND:
+    case AssetType::BOND:
       return kBond;
-    case STOCK:
+    case AssetType::STOCK:
       return kStock;
-    case CALL_OPTION:
+    case AssetType::CALL_OPTION:
       return kCallOption;
-    case PUT_OPTION:
+    case AssetType::PUT_OPTION:
       return kPutOption;
-    case FUTURE:
+    case AssetType::FUTURE:
       return kFuture;
   }
 }

--- a/src/qfm/asset/trait/strike_price_trait.cpp
+++ b/src/qfm/asset/trait/strike_price_trait.cpp
@@ -12,7 +12,7 @@ StrikePriceTrait::StrikePriceTrait(
     const AssetStrikePrice& strike_price) noexcept
     : AssetTrait(StrikePriceTrait::Key, std::string(strike_price)) {}
 
-StrikePriceTrait::StrikePriceTrait(const double& strike_price) noexcept
+StrikePriceTrait::StrikePriceTrait(double strike_price) noexcept
     : AssetTrait(StrikePriceTrait::Key, std::to_string(strike_price)) {}
 
 const std::string StrikePriceTrait::Key = "strike_price";


### PR DESCRIPTION
Check [guideline] for reference.

[guideline]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f16-for-in-parameters-pass-cheaply-copied-types-by-value-and-others-by-reference-to-const
