### PR TITLE
Use `T{e}` notation for construction

### DIFF
--- a/src/qfm/asset/asset_type.cpp
+++ b/src/qfm/asset/asset_type.cpp
@@ -4,12 +4,12 @@ namespace qfm {
 namespace asset {
 
 namespace {
-const std::string kCurrency = "currency";
-const std::string kBond = "bond";
-const std::string kStock = "stock";
-const std::string kCallOption = "call_option";
-const std::string kPutOption = "put_option";
-const std::string kFuture = "future";
+const std::string kCurrency{"currency"};
+const std::string kBond{"bond"};
+const std::string kStock{"stock"};
+const std::string kCallOption{"call_option"};
+const std::string kPutOption{"put_option"};
+const std::string kFuture{"future"};
 }  // namespace
 
 std::string ToString(const AssetType& type) {


### PR DESCRIPTION
See [guideline].

[guideline]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es64-use-the-tenotation-for-construction