### PR TITLE
Ensure `ALL_CAPS` are not used for enumerators

### DIFF
--- a/include/qfm/asset/asset_type.hpp
+++ b/include/qfm/asset/asset_type.hpp
@@ -5,7 +5,7 @@
 namespace qfm {
 namespace asset {
 
-enum class AssetType { CURRENCY, BOND, STOCK, CALL_OPTION, PUT_OPTION, FUTURE };
+enum class AssetType { currency, bond, stock, call_option, put_option, future };
 
 std::string ToString(const AssetType& type);
 

--- a/main.cpp
+++ b/main.cpp
@@ -19,7 +19,7 @@ int main() {
   std::cout << "Outputting random value: " << cdf(gaussian, 2) << std::endl;
 
   std::string ticker{"fake_ticker"};
-  qfm::asset::AssetType type{qfm::asset::AssetType::CALL_OPTION};
+  qfm::asset::AssetType type{qfm::asset::AssetType::call_option};
   qfm::asset::AssetExpiration expiration{1704067200};
   qfm::asset::AssetStrikePrice strike_price{10};
   qfm::asset::AssetTraitSet traits{

--- a/src/qfm/asset/asset_type.cpp
+++ b/src/qfm/asset/asset_type.cpp
@@ -14,17 +14,17 @@ const std::string kFuture = "future";
 
 std::string ToString(const AssetType& type) {
   switch (type) {
-    case AssetType::CURRENCY:
+    case AssetType::currency:
       return kCurrency;
-    case AssetType::BOND:
+    case AssetType::bond:
       return kBond;
-    case AssetType::STOCK:
+    case AssetType::stock:
       return kStock;
-    case AssetType::CALL_OPTION:
+    case AssetType::call_option:
       return kCallOption;
-    case AssetType::PUT_OPTION:
+    case AssetType::put_option:
       return kPutOption;
-    case AssetType::FUTURE:
+    case AssetType::future:
       return kFuture;
   }
 }


### PR DESCRIPTION
See [guideline].

[guideline]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#enum5-dont-use-all_caps-for-enumerators