### PR TITLE
Run `clang-format` across all the codebase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,43 +4,21 @@ Language:        Cpp
 AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None
-AlignConsecutiveAssignments:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    true
-AlignConsecutiveBitFields:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    false
-AlignConsecutiveDeclarations:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    false
-AlignConsecutiveMacros:
-  Enabled:         false
-  AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    false
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Left
 AlignOperands:   Align
-AlignTrailingComments:
-  Kind:            Always
-  OverEmptyLines:  0
+AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortEnumsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
@@ -50,18 +28,17 @@ AttributeMacros:
   - __capability
 BinPackArguments: true
 BinPackParameters: true
-BitFieldColonSpacing: Both
 BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      false
   AfterControlStatement: Never
   AfterEnum:       false
-  AfterExternBlock: false
   AfterFunction:   false
   AfterNamespace:  false
   AfterObjCDeclaration: false
   AfterStruct:     false
   AfterUnion:      false
+  AfterExternBlock: false
   BeforeCatch:     false
   BeforeElse:      false
   BeforeLambdaBody: false
@@ -70,28 +47,33 @@ BraceWrapping:
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-BreakAfterAttributes: Never
-BreakAfterJavaFieldAnnotations: false
-BreakArrays:     true
 BreakBeforeBinaryOperators: None
-BreakBeforeConceptDeclarations: Always
+BreakBeforeConceptDeclarations: true
 BreakBeforeBraces: Attach
-BreakBeforeInlineASMColon: OnlyMultiline
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeColon
+BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
 CompactNamespaces: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
+DeriveLineEnding: true
 DerivePointerAlignment: true
 DisableFormat:   false
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: NextLine
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
@@ -120,29 +102,19 @@ IncludeCategories:
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: false
-IndentCaseBlocks: false
 IndentCaseLabels: true
-IndentExternBlock: AfterExternBlock
+IndentCaseBlocks: false
 IndentGotoLabels: true
 IndentPPDirectives: None
-IndentRequiresClause: true
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
 IndentWidth:     2
 IndentWrappedFunctionNames: false
-InsertBraces:    false
-InsertNewlineAtEOF: false
 InsertTrailingCommas: None
-IntegerLiteralSeparator:
-  Binary:          0
-  BinaryMinDigits: 0
-  Decimal:         0
-  DecimalMinDigits: 0
-  Hex:             0
-  HexMinDigits:    0
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 LambdaBodyIndentation: Signature
-LineEnding:      DeriveLF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
@@ -152,7 +124,6 @@ ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
-PackConstructorInitializers: NextLine
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300
@@ -161,11 +132,10 @@ PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
 PointerAlignment: Left
 PPIndentWidth:   -1
-QualifierAlignment: Leave
 RawStringFormats:
   - Language:        Cpp
     Delimiters:
@@ -199,18 +169,14 @@ RawStringFormats:
 ReferenceAlignment: Pointer
 ReflowComments:  true
 RemoveBracesLLVM: false
-RemoveSemicolon: false
-RequiresClausePosition: OwnLine
-RequiresExpressionIndentation: OuterScope
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1
 SortIncludes:    CaseSensitive
 SortJavaStaticImport: Before
-SortUsingDeclarations: LexicographicNumeric
+SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
-SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
@@ -224,11 +190,9 @@ SpaceBeforeParensOptions:
   AfterFunctionDeclarationName: false
   AfterIfMacros:   true
   AfterOverloadedOperator: false
-  AfterRequiresInClause: false
-  AfterRequiresInExpression: false
   BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
@@ -241,6 +205,8 @@ SpacesInLineCommentPrefix:
   Maximum:         -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
 Standard:        Auto
 StatementAttributeLikeMacros:
   - Q_EMIT
@@ -248,12 +214,12 @@ StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
 TabWidth:        8
+UseCRLF:         false
 UseTab:          Never
 WhitespaceSensitiveMacros:
-  - BOOST_PP_STRINGIZE
-  - CF_SWIFT_NAME
-  - NS_SWIFT_NAME
-  - PP_STRINGIZE
   - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
 ...
-

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,23 @@
+name: clang-format
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: clang-format files
+      run: find src include main.cpp -name '*.cpp' -o -name '*.hpp' | xargs -n1 clang-format -i
+
+    - name: Check if something changed
+      run: git diff-index --quiet HEAD || exit 1

--- a/include/qfm/asset/asset_strike_price.hpp
+++ b/include/qfm/asset/asset_strike_price.hpp
@@ -11,11 +11,11 @@ class AssetStrikePrice {
   ~AssetStrikePrice() = default;
 
   bool operator==(double price) const;
-  bool operator!=( double price) const;
-  bool operator<=( double price) const;
-  bool operator>=( double price) const;
-  bool operator<( double price) const;
-  bool operator>( double price) const;
+  bool operator!=(double price) const;
+  bool operator<=(double price) const;
+  bool operator>=(double price) const;
+  bool operator<(double price) const;
+  bool operator>(double price) const;
 
   operator double() const;
   operator std::string() const;

--- a/src/qfm/asset/option.cpp
+++ b/src/qfm/asset/option.cpp
@@ -2,11 +2,12 @@
 // Created by Durante, Matteo on 19/8/23.
 //
 
+#include "qfm/asset/option.hpp"
+
 #include "qfm/asset/asset.hpp"
 #include "qfm/asset/asset_expiration.hpp"
 #include "qfm/asset/asset_strike_price.hpp"
 #include "qfm/asset/asset_type.hpp"
-#include "qfm/asset/option.hpp"
 #include "qfm/asset/trait/expiration_trait.hpp"
 #include "qfm/asset/trait/strike_price_trait.hpp"
 #include "qfm/asset/trait/underlying_trait.hpp"

--- a/src/qfm/market_data_provider.cpp
+++ b/src/qfm/market_data_provider.cpp
@@ -2,10 +2,11 @@
 // Created by Durante, Matteo on 19/8/23.
 //
 
+#include "qfm/market_data_provider.hpp"
+
 #include <memory>
 
 #include "qfm/asset/asset.hpp"
-#include "qfm/market_data_provider.hpp"
 
 namespace qfm {
 

--- a/src/qfm/pricing/model/black_scholes.cpp
+++ b/src/qfm/pricing/model/black_scholes.cpp
@@ -2,6 +2,8 @@
 // Created by Durante, Matteo on 19/8/23.
 //
 
+#include "qfm/pricing/model/black_scholes.hpp"
+
 #include <boost/math/distributions/normal.hpp>
 #include <chrono>
 #include <cmath>
@@ -12,7 +14,6 @@
 #include "qfm/asset/trait/strike_price_trait.hpp"
 #include "qfm/asset/trait/underlying_trait.hpp"
 #include "qfm/market_data_provider.hpp"
-#include "qfm/pricing/model/black_scholes.hpp"
 #include "qfm/pricing/model/model.hpp"
 
 namespace qfm {

--- a/src/qfm/pricing/pricing.cpp
+++ b/src/qfm/pricing/pricing.cpp
@@ -2,13 +2,14 @@
 // Created by Durante, Matteo on 19/8/23.
 //
 
+#include "qfm/pricing/pricing.hpp"
+
 #include <memory>
 #include <string>
 
 #include "qfm/asset/asset.hpp"
 #include "qfm/pricing/model/model.hpp"
 #include "qfm/pricing/model/null_model.hpp"
-#include "qfm/pricing/pricing.hpp"
 
 namespace qfm {
 namespace pricing {


### PR DESCRIPTION
This should be the last time we need to run this upstream, as the check has been automated in #54.