### PR TITLE
Get current time in Black-Scholes model

### DIFF
--- a/src/qfm/pricing/model/black_scholes.cpp
+++ b/src/qfm/pricing/model/black_scholes.cpp
@@ -37,7 +37,12 @@ double BlackScholes::GetAssetPrice(
   double spot_price = market_data_provider_->GetAssetSpotPrice(underlying);
   double interest_rate = market_data_provider_->GetInterestRate();
 
-  int64_t current_time = 0;  // TODO: Get the current time
+  // This depends on the system_clock epoch being the Unix epoch, which is true
+  // from C++20 and the de facto standard in the preceding versions
+  int64_t current_time =
+      std::chrono::duration_cast<std::chrono::seconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count();
   int64_t time_to_maturity = expiration - current_time;
 
   double d_one = (std::log(spot_price / strike_price) +


### PR DESCRIPTION
This deals with issue https://github.com/Waifod/quant_finance_models/issues/18.

We need to provide the correct current time for the model to determine the time to expiration and therefore the fair price.

Here we are assuming that the `system_clock epoch` coincides with the `Unix epoch`, which is true from C++20 and the de facto standard in the previous versions.