### PR TITLE
Allow setting interest rate in MarketDataProvider and require it in its constructor

### DIFF
--- a/include/qfm/market_data_provider.hpp
+++ b/include/qfm/market_data_provider.hpp
@@ -12,8 +12,13 @@ namespace qfm {
 
 class MarketDataProvider {
  public:
+  MarketDataProvider(const double interest_rate) noexcept;
   double GetAssetSpotPrice(const std::string& asset) const noexcept;
   double GetAssetVolatility(const std::string& asset) const noexcept;
   double GetInterestRate() const noexcept;
+  void SetInterestRate(const double interest_rate) noexcept;
+
+ private:
+  double interest_rate_;
 };
 }  // namespace qfm

--- a/main.cpp
+++ b/main.cpp
@@ -51,8 +51,9 @@ int main() {
        qfm::asset::trait::StrikePriceTrait(strike_price)}};
   auto asset = std::make_shared<qfm::asset::Asset>(ticker, type, traits);
 
+  double interest_rate = 1.02;
   std::shared_ptr<qfm::MarketDataProvider> market_data_provider =
-      std::make_shared<qfm::MarketDataProvider>();
+      std::make_shared<qfm::MarketDataProvider>(interest_rate);
 
   auto model =
       std::make_shared<qfm::pricing::model::BlackScholes>(market_data_provider);

--- a/src/qfm/market_data_provider.cpp
+++ b/src/qfm/market_data_provider.cpp
@@ -10,6 +10,9 @@
 
 namespace qfm {
 
+MarketDataProvider::MarketDataProvider(const double interest_rate) noexcept
+    : interest_rate_{interest_rate} {}
+
 double MarketDataProvider::GetAssetSpotPrice(
     const std::string& asset) const noexcept {
   return 1.0;
@@ -20,6 +23,12 @@ double MarketDataProvider::GetAssetVolatility(
   return 1.0;
 }
 
-double MarketDataProvider::GetInterestRate() const noexcept { return 1.0; }
+double MarketDataProvider::GetInterestRate() const noexcept {
+  return interest_rate_;
+}
+
+void MarketDataProvider::SetInterestRate(const double interest_rate) noexcept {
+  interest_rate_ = interest_rate;
+}
 
 }  // namespace qfm


### PR DESCRIPTION
This deals with issue https://github.com/Waifod/quant_finance_models/issues/32.

We need to provide a way to set the right interest rate in the MarketDataProvider, so that it can provide the correct value on demand.

Also, since it should always be available, we require it in the constructor of `MarketDataProvider`.

---

## Testing

We updated `main.cpp` to construct the `MarketDataProvider` correctly, then we executed it.