### PR TITLE
Rely on class AssetTicker for tickers

### DIFF
--- a/include/qfm/asset/asset.hpp
+++ b/include/qfm/asset/asset.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "qfm/asset/asset_ticker.hpp"
 #include "qfm/asset/asset_trait_set.hpp"
 #include "qfm/asset/asset_type.hpp"
 
@@ -10,14 +11,14 @@ namespace asset {
 
 class Asset {
  public:
-  explicit Asset(const std::string& ticker, const AssetType& type,
+  explicit Asset(const AssetTicker& ticker, const AssetType& type,
                  const AssetTraitSet& traits) noexcept;
-  std::string GetTicker() const noexcept;
+  AssetTicker GetTicker() const noexcept;
   AssetType GetType() const noexcept;
   AssetTraitSet GetTraits() const noexcept;
 
  protected:
-  std::string ticker_;
+  AssetTicker ticker_;
   AssetType type_;
   AssetTraitSet traits_;
 };

--- a/include/qfm/asset/option.hpp
+++ b/include/qfm/asset/option.hpp
@@ -7,6 +7,7 @@
 #include "qfm/asset/asset.hpp"
 #include "qfm/asset/asset_expiration.hpp"
 #include "qfm/asset/asset_strike_price.hpp"
+#include "qfm/asset/asset_ticker.hpp"
 #include "qfm/asset/asset_trait_set.hpp"
 #include "qfm/asset/asset_type.hpp"
 
@@ -15,9 +16,7 @@ namespace asset {
 
 class Option : public Asset {
  public:
-  Option(const std::string& ticker, const AssetType& type,
-         const AssetTraitSet& traits) noexcept;
-  std::string GetUnderlying() const noexcept;
+  AssetTicker GetUnderlying() const noexcept;
   AssetStrikePrice GetStrikePrice() const noexcept;
   AssetExpiration GetExpirationDate() const noexcept;
 };

--- a/include/qfm/market_data_provider.hpp
+++ b/include/qfm/market_data_provider.hpp
@@ -7,14 +7,15 @@
 #include <memory>
 
 #include "qfm/asset/asset.hpp"
+#include "qfm/asset/asset_ticker.hpp"
 
 namespace qfm {
 
 class MarketDataProvider {
  public:
   MarketDataProvider(const double interest_rate) noexcept;
-  double GetAssetSpotPrice(const std::string& asset) const noexcept;
-  double GetAssetVolatility(const std::string& asset) const noexcept;
+  double GetAssetSpotPrice(const asset::AssetTicker& asset) const noexcept;
+  double GetAssetVolatility(const asset::AssetTicker& asset) const noexcept;
   double GetInterestRate() const noexcept;
   void SetInterestRate(const double interest_rate) noexcept;
 

--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@
 
 #include "qfm/asset/asset_expiration.hpp"
 #include "qfm/asset/asset_strike_price.hpp"
+#include "qfm/asset/asset_ticker.hpp"
 #include "qfm/asset/asset_trait_set.hpp"
 #include "qfm/asset/asset_type.hpp"
 #include "qfm/asset/option.hpp"
@@ -42,7 +43,7 @@ int main() {
   auto gaussian = boost::math::normal_distribution(0, 1);
   std::cout << "Outputting random value: " << cdf(gaussian, 2) << std::endl;
 
-  std::string ticker{"fake_ticker"};
+  qfm::asset::AssetTicker ticker{"fake_ticker"};
   qfm::asset::AssetType type{qfm::asset::AssetType::call_option};
   qfm::asset::AssetExpiration expiration{1704067200};
   qfm::asset::AssetStrikePrice strike_price{10};

--- a/src/qfm/asset/asset.cpp
+++ b/src/qfm/asset/asset.cpp
@@ -4,17 +4,18 @@
 
 #include "qfm/asset/asset.hpp"
 
+#include "qfm/asset/asset_ticker.hpp"
 #include "qfm/asset/asset_trait_set.hpp"
 #include "qfm/asset/asset_type.hpp"
 
 namespace qfm {
 namespace asset {
 
-Asset::Asset(const std::string& ticker, const AssetType& type,
+Asset::Asset(const AssetTicker& ticker, const AssetType& type,
              const AssetTraitSet& traits) noexcept
     : ticker_{ticker}, type_{type}, traits_{traits} {}
 
-std::string Asset::GetTicker() const noexcept { return ticker_; }
+AssetTicker Asset::GetTicker() const noexcept { return ticker_; }
 
 AssetType Asset::GetType() const noexcept { return type_; }
 

--- a/src/qfm/asset/option.cpp
+++ b/src/qfm/asset/option.cpp
@@ -7,6 +7,7 @@
 #include "qfm/asset/asset.hpp"
 #include "qfm/asset/asset_expiration.hpp"
 #include "qfm/asset/asset_strike_price.hpp"
+#include "qfm/asset/asset_ticker.hpp"
 #include "qfm/asset/asset_type.hpp"
 #include "qfm/asset/trait/expiration_trait.hpp"
 #include "qfm/asset/trait/strike_price_trait.hpp"
@@ -15,12 +16,8 @@
 namespace qfm {
 namespace asset {
 
-Option::Option(const std::string& ticker, const AssetType& type,
-               const AssetTraitSet& traits) noexcept
-    : Asset(ticker, type, traits) {}
-
-std::string Option::GetUnderlying() const noexcept {
-  return traits_.GetValue<trait::UnderlyingTrait>();
+AssetTicker Option::GetUnderlying() const noexcept {
+  return AssetTicker(traits_.GetValue<trait::UnderlyingTrait>());
 }
 
 AssetStrikePrice Option::GetStrikePrice() const noexcept {

--- a/src/qfm/market_data_provider.cpp
+++ b/src/qfm/market_data_provider.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "qfm/asset/asset.hpp"
+#include "qfm/asset/asset_ticker.hpp"
 
 namespace qfm {
 
@@ -14,12 +15,12 @@ MarketDataProvider::MarketDataProvider(const double interest_rate) noexcept
     : interest_rate_{interest_rate} {}
 
 double MarketDataProvider::GetAssetSpotPrice(
-    const std::string& asset) const noexcept {
+    const asset::AssetTicker& asset) const noexcept {
   return 1.0;
 }
 
 double MarketDataProvider::GetAssetVolatility(
-    const std::string& asset) const noexcept {
+    const asset::AssetTicker& asset) const noexcept {
   return 1.0;
 }
 

--- a/src/qfm/pricing/model/black_scholes.cpp
+++ b/src/qfm/pricing/model/black_scholes.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 
 #include "qfm/asset/asset.hpp"
+#include "qfm/asset/asset_ticker.hpp"
 #include "qfm/asset/asset_type.hpp"
 #include "qfm/asset/trait/expiration_trait.hpp"
 #include "qfm/asset/trait/strike_price_trait.hpp"
@@ -37,7 +38,8 @@ double BlackScholes::GetAssetPrice(
   }
 
   asset::AssetTraitSet traits = asset->GetTraits();
-  std::string underlying = traits.GetValue<asset::trait::UnderlyingTrait>();
+  asset::AssetTicker underlying =
+      asset::AssetTicker(traits.GetValue<asset::trait::UnderlyingTrait>());
   double strike_price =
       std::stod(traits.GetValue<asset::trait::StrikePriceTrait>());
   int64_t expiration =

--- a/src/qfm/pricing/model/null_model.cpp
+++ b/src/qfm/pricing/model/null_model.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "qfm/asset/asset.hpp"
+#include "qfm/asset/asset_ticker.hpp"
 #include "qfm/market_data_provider.hpp"
 #include "qfm/pricing/model/model.hpp"
 
@@ -17,7 +18,7 @@ NullModel::NullModel(
 double NullModel::GetAssetPrice(
     std::shared_ptr<asset::Asset> asset) const noexcept {
   std::cout << "No pricing model provided. Returning dummy value for asset: " +
-                   asset->GetTicker()
+                   std::string(asset->GetTicker())
             << std::endl;
   return 1.0;
 }


### PR DESCRIPTION
This takes care of issue https://github.com/Waifod/quant_finance_models/issues/22.

This change replaces simple strings for tickers with the dedicated `AssetTicker` class.

---

We updated the `main.cpp` accordingly for testing purposes.