### PR TITLE
Add GoogleTest framework and sample test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ jobs:
     - name: Install cURL libraries
       run: sudo apt-get install curl libssl-dev libcurl4-openssl-dev
 
+    - name: Install GoogleTest libraries
+      run: sudo apt-get install googletest libgtest-dev
+
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -23,14 +23,7 @@ jobs:
       run: sudo apt-get install curl libssl-dev libcurl4-openssl-dev
 
     - name: Install GoogleTest libraries
-      run: >
-        sudo apt-get install libgtest-dev &&
-        cd /usr/src/gtest &&
-        sudo cmake CMakeLists.txt &&
-        sudo make &&
-        sudo cp lib/*.a /usr/lib &&
-        sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a &&
-        sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
+      run: sudo apt-get install libgmock-dev libgtest-dev 
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,4 +1,4 @@
-name: build
+name: run-unit-tests
 
 on:
   push:
@@ -23,10 +23,20 @@ jobs:
       run: sudo apt-get install curl libssl-dev libcurl4-openssl-dev
 
     - name: Install GoogleTest libraries
-      run: sudo apt-get install googletest libgtest-dev
+      run: >
+        sudo apt-get install libgtest-dev &&
+        cd /usr/src/gtest &&
+        sudo cmake CMakeLists.txt &&
+        sudo make &&
+        sudo cp lib/*.a /usr/lib &&
+        sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a &&
+        sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Run unit tests
+      run: ${{github.workspace}}/build/test/runUnitTests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,10 @@ include_directories(${Boost_INCLUDE_DIR})
 find_package(CURL REQUIRED)
 include_directories(${CURL_INCLUDE_DIR})
 
-find_package(GTest REQUIRED)
-include_directories(${GTest_INCLUDE_DIR})
-
 include_directories(include)
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 add_executable(quant_finance_models "main.cpp" ${SOURCES})
-target_link_libraries(quant_finance_models LINK_PUBLIC ${Boost_LIBRARIES} ${CURL_LIBRARIES} ${GTest_LIBRARIES})
+target_link_libraries(quant_finance_models LINK_PUBLIC ${Boost_LIBRARIES} ${CURL_LIBRARIES})
 
 # Testing
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,14 +20,5 @@ file(GLOB_RECURSE SOURCES "src/*.cpp")
 add_executable(quant_finance_models "main.cpp" ${SOURCES})
 target_link_libraries(quant_finance_models LINK_PUBLIC ${Boost_LIBRARIES} ${CURL_LIBRARIES} ${GTest_LIBRARIES})
 
-<<<<<<< HEAD
-## Testing
-enable_testing()
-include_directories(tests)
-file(GLOB_RECURSE TESTS "tests/*.cpp")
-add_executable(runUnitTests tests/qfm/asset/test_asset.cpp ${TESTS})
-gtest_discover_tests(runUnitTests)
-=======
 # Testing
 add_subdirectory(test)
->>>>>>> f17942a (Add GoogleTest framework)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,22 @@ include_directories(${Boost_INCLUDE_DIR})
 find_package(CURL REQUIRED)
 include_directories(${CURL_INCLUDE_DIR})
 
+find_package(GTest REQUIRED)
+include_directories(${GTest_INCLUDE_DIR})
+
 include_directories(include)
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 add_executable(quant_finance_models "main.cpp" ${SOURCES})
-target_link_libraries(quant_finance_models LINK_PUBLIC ${Boost_LIBRARIES} ${CURL_LIBRARIES})
+target_link_libraries(quant_finance_models LINK_PUBLIC ${Boost_LIBRARIES} ${CURL_LIBRARIES} ${GTest_LIBRARIES})
 
-# add_subdirectory(test)
+<<<<<<< HEAD
+## Testing
+enable_testing()
+include_directories(tests)
+file(GLOB_RECURSE TESTS "tests/*.cpp")
+add_executable(runUnitTests tests/qfm/asset/test_asset.cpp ${TESTS})
+gtest_discover_tests(runUnitTests)
+=======
+# Testing
+add_subdirectory(test)
+>>>>>>> f17942a (Add GoogleTest framework)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,12 @@
+## Testing
+find_package(GTest REQUIRED)
+include_directories(${GTest_INCLUDE_DIR})
+enable_testing()
+include_directories(../include)
+file(GLOB_RECURSE UNIT_TEST_SOURCES "*.cpp")
+add_executable(runUnitTests ${SOURCES} ${UNIT_TEST_SOURCES})
+target_link_libraries(
+  runUnitTests
+  GTest::gtest_main
+)
+gtest_discover_tests(runUnitTests)

--- a/test/unit/qfm/asset/test_asset.cpp
+++ b/test/unit/qfm/asset/test_asset.cpp
@@ -1,0 +1,16 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "qfm/asset/asset.hpp"
+#include "qfm/asset/asset_trait_set.hpp"
+#include "qfm/asset/asset_type.hpp"
+
+using namespace qfm::asset;
+
+TEST(TestAsset, GetTicker) {
+  auto fake_ticker = AssetTicker("fake_ticker");
+  auto fake_type = AssetType::stock;
+  auto fake_traits = AssetTraitSet(std::set<AssetTrait>());
+  auto asset = Asset(fake_ticker, fake_type, fake_traits);
+  EXPECT_EQ(asset.GetTicker(), fake_ticker);
+}


### PR DESCRIPTION
This PR tackles issue https://github.com/Waifod/quant_finance_models/issues/35.

---

We add the GoogleTest framework to handle unit testing for our project.

We provide a sample test to verify that the integration was done correctly.

We extend the `build` workflow to run the unit tests and rename it to `run-unit-tests`.