### PR TITLE
Add platform update to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Update platform
+      run: sudo apt-get update
+
     - name: Install Boost libraries
       run: sudo apt-get install libboost-all-dev
 


### PR DESCRIPTION
The build workflow is failing because it's unable to fetch a package. We try to fix that by first updating the platform.