### PR TITLE
Add GoogleTest framework and extend build workflow

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -1,4 +1,4 @@
-name: build
+name: run-unit-tests
 
 on:
   push:
@@ -25,8 +25,14 @@ jobs:
     - name: Install cURL libraries
       run: sudo apt-get install curl libssl-dev libcurl4-openssl-dev
 
+    - name: Install GoogleTest libraries
+      run: sudo apt-get install libgmock-dev libgtest-dev 
+
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Run unit tests
+      run: ${{github.workspace}}/build/test/runUnitTests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,4 +17,5 @@ file(GLOB_RECURSE SOURCES "src/*.cpp")
 add_executable(quant_finance_models "main.cpp" ${SOURCES})
 target_link_libraries(quant_finance_models LINK_PUBLIC ${Boost_LIBRARIES} ${CURL_LIBRARIES})
 
-# add_subdirectory(test)
+# Testing
+add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,12 @@
+## Testing
+find_package(GTest REQUIRED)
+include_directories(${GTest_INCLUDE_DIR})
+enable_testing()
+include_directories(../include)
+file(GLOB_RECURSE UNIT_TEST_SOURCES "*.cpp")
+add_executable(runUnitTests ${SOURCES} ${UNIT_TEST_SOURCES})
+target_link_libraries(
+  runUnitTests
+  GTest::gtest_main
+)
+gtest_discover_tests(runUnitTests)

--- a/test/unit/qfm/asset/test_asset.cpp
+++ b/test/unit/qfm/asset/test_asset.cpp
@@ -1,0 +1,16 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "qfm/asset/asset.hpp"
+#include "qfm/asset/asset_trait_set.hpp"
+#include "qfm/asset/asset_type.hpp"
+
+using namespace qfm::asset;
+
+TEST(TestAsset, GetTicker) {
+  auto fake_ticker = AssetTicker("fake_ticker");
+  auto fake_type = AssetType::stock;
+  auto fake_traits = AssetTraitSet(std::set<AssetTrait>());
+  auto asset = Asset(fake_ticker, fake_type, fake_traits);
+  EXPECT_EQ(asset.GetTicker(), fake_ticker);
+}


### PR DESCRIPTION
This PR tackles issue https://github.com/Waifod/quant_finance_models/issues/35.

---

We add the GoogleTest framework to handle unit testing for our project.

We provide a sample test to verify that the integration was done correctly.

We extend the `build` workflow to run the unit tests and rename it to `run-unit-tests`.