### PR TITLE
Add default case to AssetType ToString

### DIFF
--- a/src/qfm/asset/asset_type.cpp
+++ b/src/qfm/asset/asset_type.cpp
@@ -16,6 +16,7 @@ const std::string kStock{"stock"};
 const std::string kCallOption{"call_option"};
 const std::string kPutOption{"put_option"};
 const std::string kFuture{"future"};
+const std::string kInvalid{"invalid"};
 }  // namespace
 
 std::string ToString(const AssetType& type) {
@@ -32,6 +33,8 @@ std::string ToString(const AssetType& type) {
       return kPutOption;
     case AssetType::future:
       return kFuture;
+    default:
+      return kInvalid;
   }
 }
 

--- a/test/unit/qfm/asset/test_asset.cpp
+++ b/test/unit/qfm/asset/test_asset.cpp
@@ -1,4 +1,9 @@
-#include <gmock/gmock.h>
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2023 David Alvarez Rosa, Matteo Durante
+ */
+
 #include <gtest/gtest.h>
 
 #include "qfm/asset/asset.hpp"


### PR DESCRIPTION
When building we are receiving the following warning message about a `switch` statement without a `default case`.

```
/home/runner/work/quant_finance_models/quant_finance_models/src/qfm/asset/asset_type.cpp: In function ‘std::string qfm::asset::ToString(const qfm::asset::AssetType&)’:
/home/runner/work/quant_finance_models/quant_finance_models/src/qfm/asset/asset_type.cpp:36:1: warning: control reaches end of non-void function [-Wreturn-type]
   36 | }
      | ^
```

This change provides it.