### PR TITLE
Create .clang-tidy configuration file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,16 @@
+Checks: >
+  -*,
+  boost-*,
+  bugprone-*
+  cert-*
+  clang-analyzer-*
+  concurrency-*
+  # cppcoreguidelines-*,
+  # google-*,
+  misc-*
+  # modernize-*
+  # performance-*,
+  # portability-*,
+  # readability-*,
+
+WarningsAsErrors: "*"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(QuantFinanceModels
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_CXX_CLANG_TIDY clang-tidy -checks=-*,readability-*,boost-*,cppcoreguidelines-*,google-*,performance-*,portability-*,modernize-*)
+set(CMAKE_CXX_CLANG_TIDY clang-tidy)
 
 find_package(Boost 1.65 REQUIRED)
 find_package(nlohmann_json 3.2.0 REQUIRED)


### PR DESCRIPTION
I'm setting `WarningAsError` to `*` which means that all warning as treated as errors.  Subsequent PRs will first fix, and then enable more checks.